### PR TITLE
width and height should be initialized to zero if nil in ItemInfo

### DIFF
--- a/Sources/Impl/ItemInfo.swift
+++ b/Sources/Impl/ItemInfo.swift
@@ -234,7 +234,13 @@ class ItemInfo {
                 }
             }
 
-            assert(height != nil && width != nil, "should not occurred") //remove this
+            if height == nil {
+                height = 0
+            }
+
+            if width == nil {
+                width = 0
+            }
             
             applySizeMinMax()
             applyAspectRatioIfNeeded(.adjustCrossAxis)

--- a/Sources/Impl/ItemInfo.swift
+++ b/Sources/Impl/ItemInfo.swift
@@ -234,7 +234,7 @@ class ItemInfo {
                 }
             }
 
-            assert(height != nil && width != nil, "should not occurred")
+            assert(height != nil && width != nil, "should not occurred") //remove this
             
             applySizeMinMax()
             applyAspectRatioIfNeeded(.adjustCrossAxis)


### PR DESCRIPTION
## 📖 Description

The assertion (`assert(height != nil && width != nil, "should not occurred")`) was causing crash when width or height were not initialized