### PR TITLE
Fix retain cycle in StackItem

### DIFF
--- a/Sources/Impl/Container.swift
+++ b/Sources/Impl/Container.swift
@@ -21,7 +21,7 @@
 import UIKit
 
 class Container {
-    fileprivate let stackView: StackView
+    fileprivate weak var stackView: StackView?
     var width: CGFloat?
     var height: CGFloat?
     var innerWidth: CGFloat?
@@ -29,11 +29,11 @@ class Container {
     var items: [ItemInfo] = []
 
     var direction: SDirection {
-        return stackView.direction
+        return stackView?.direction ?? .column
     }
 
     var alignItems: SAlignItems {
-        return stackView.alignItems
+        return stackView?.alignItems ?? .stretch
     }
 
     var mainAxisLength: CGFloat? {
@@ -98,6 +98,7 @@ class Container {
     }
 
     fileprivate func initializeInnerSize() {
+        guard let stackView = stackView else { return }
         if let paddingLeft = stackView._paddingLeft?.resolveWidth(container: self) {
             self.paddingLeft = paddingLeft
         }

--- a/Sources/Impl/ItemInfo.swift
+++ b/Sources/Impl/ItemInfo.swift
@@ -20,9 +20,9 @@
 import UIKit
 
 class ItemInfo {
-    var view: UIView
-    var stackItem: StackItemImpl
-    var container: Container
+    weak var view: UIView?
+    weak var stackItem: StackItemImpl?
+    weak var container: Container?
 
     private var _width: CGFloat?
     var width: CGFloat? {
@@ -96,15 +96,15 @@ class ItemInfo {
 
     var measureType: MeasureType? {
         get {
-            return stackItem.measureType
+            return stackItem?.measureType
         }
         set {
-            stackItem.measureType = newValue
+            stackItem?.measureType = newValue
         }
     }
     
     private var direction: SDirection {
-        return container.direction
+        return container?.direction ?? .column
     }
     
     init(_ stackItem: StackItemImpl, container: Container, mode: LayoutMode) {
@@ -129,18 +129,18 @@ class ItemInfo {
     }
 
     func isWidthDefined() -> Bool {
-        return stackItem.width != nil || minWidth != nil
+        return stackItem?.width != nil || minWidth != nil
     }
 
     func isHeightDefined() -> Bool {
-        return stackItem.height != nil || minHeight != nil
+        return stackItem?.height != nil || minHeight != nil
     }
 
     func isCrossAxisFlexible() -> Bool {
         if direction == .column {
-            return stackItem.width == nil
+            return stackItem?.width == nil
         } else {
-            return stackItem.height == nil
+            return stackItem?.height == nil
         }
     }
 
@@ -149,6 +149,7 @@ class ItemInfo {
     }
 
     func resetToStackItemProperties() {
+        guard let stackItem = stackItem, let container = container else { return }
         self.width = stackItem.width?.resolveWidth(container: container)
         if let minWidth = minWidth, let width = width, width < minWidth {
             self.width = minWidth
@@ -161,6 +162,7 @@ class ItemInfo {
     }
     
     func measureItem(initialMeasure: Bool) {
+        guard let view = view, let stackItem = stackItem, let container = container else { return }
         let stretchedCrossAxisLength = resolveStretchedCrossAxisLength()
         var isMeasured = false
 
@@ -256,6 +258,7 @@ class ItemInfo {
     }
 
     private func resolveStretchedCrossAxisLength() -> CGFloat? {
+        guard let stackItem = stackItem, let container = container else { return nil }
         if stackItem.resolveStackItemAlign(stackAlignItems: container.alignItems) == .stretch, let containerCrossAxisInnerLength = container.crossAxisInnerLength {
             if isCrossAxisFlexible() {
                 var crossAxisLength = stackItem.applyMargins(toCrossAxisLength: containerCrossAxisInnerLength, container: container)
@@ -268,7 +271,7 @@ class ItemInfo {
     }
 
     private func measureAterGrowShrink() {
-        if stackItem._aspectRatio != nil {
+        if stackItem?._aspectRatio != nil {
             applyAspectRatioIfNeeded(.adjustCrossAxis)
             applySizeMinMax()
         } else {
@@ -284,6 +287,7 @@ class ItemInfo {
     }
 
     private func applyAspectRatioIfNeeded(_ adjustType: AdjustType) {
+        guard let stackItem = stackItem, let container = container else { return }
         if let aspectRatio = stackItem._aspectRatio {
             let adjustWidth: Bool
 
@@ -325,7 +329,7 @@ class ItemInfo {
     }
 
     private func hasReachedMaxAspectRatio() -> Bool {
-        guard stackItem._aspectRatio != nil else { return false }
+        guard stackItem?._aspectRatio != nil, let stackItem = stackItem, let container = container else { return false }
 
         if direction == .column {
             if var availableWidth = container.innerWidth {
@@ -355,7 +359,7 @@ class ItemInfo {
     }
 
     private func adjustWidthToAspectRatioAndContainer(width: CGFloat) -> CGFloat {
-        guard direction == .row else { return width }
+        guard direction == .row, let stackItem = stackItem, let container = container else { return width }
         guard let aspectRatio = stackItem._aspectRatio else { return width }
         guard let availableHeight = container.innerHeight else { return width }
 
@@ -370,7 +374,7 @@ class ItemInfo {
     }
 
     private func adjustHeightToAspectRatioAndContainer(height: CGFloat) -> CGFloat {
-        guard direction == .column else { return height }
+        guard direction == .column, let stackItem = stackItem, let container = container else { return height }
         guard let aspectRatio = stackItem._aspectRatio else { return height }
         guard let availableWidth = container.innerWidth else { return height }
 
@@ -391,7 +395,7 @@ class ItemInfo {
             return 0
         } else if hasReachedMaxAspectRatio() {
             return 0
-        } else if let growFactor = stackItem.grow {
+        } else if let growFactor = stackItem?.grow {
             return growFactor
         } else {
             return 0
@@ -409,7 +413,7 @@ class ItemInfo {
 
         if let mainAxisMinLength = mainAxisMinLength, mainAxisLength <= mainAxisMinLength {
             return 0
-        } else if let shrink = stackItem.shrink {
+        } else if let shrink = stackItem?.shrink {
             return shrink * basis
         } else {
             return 0

--- a/Sources/Impl/StackItemImpl.swift
+++ b/Sources/Impl/StackItemImpl.swift
@@ -30,7 +30,7 @@ enum MeasureType {
 
 
 class StackItemImpl: NSObject, StackItem {
-    internal let view: UIView
+    internal weak var view: UIView?
 
     internal var width: Value?
     internal var minWidth: Value?
@@ -78,9 +78,9 @@ class StackItemImpl: NSObject, StackItem {
     
     @discardableResult
     public func markDirty() -> StackItem {
-        view.setNeedsLayout()
+        view?.setNeedsLayout()
 
-        if let stackView = view.superview as? StackView {
+        if let stackView = view?.superview as? StackView {
             stackView.markDirty()
         }
         return self
@@ -371,13 +371,13 @@ class StackItemImpl: NSObject, StackItem {
 
     @discardableResult
     public func backgroundColor(_ color: UIColor) -> StackItem {
-        view.backgroundColor = color
+        view?.backgroundColor = color
         return self
     }
 
     @discardableResult
     public func alpha(_ alpha: CGFloat) -> StackItem {
-        view.alpha = alpha
+        view?.alpha = alpha
         return self
     }
 }

--- a/Sources/Impl/StackView+Layout.swift
+++ b/Sources/Impl/StackView+Layout.swift
@@ -168,7 +168,7 @@ extension StackView {
         }
 
         for (index, item) in container.items.enumerated() {
-            let stackItem = item.stackItem
+            guard let stackItem = item.stackItem else { continue }
             //
             // Handle main-axis position
             if index == 0 {
@@ -212,8 +212,8 @@ extension StackView {
 
             let itemViewRect = Coordinates.adjustRectToDisplayScale(viewFrame)
 
-            if mode == .layouting {
-                Coordinates.setUntransformedViewRect(item.view, toRect: itemViewRect)
+            if mode == .layouting, let itemView = item.view {
+                Coordinates.setUntransformedViewRect(itemView, toRect: itemViewRect)
             }
 
             mainAxisOffset = direction == .column ? itemViewRect.maxY :  itemViewRect.maxX


### PR DESCRIPTION
Il y avait plusieurs trucs dans StackView qui causaient des retain cycles. Quelques weak bien placés fix le tout.

FYI: Avant ce fix, toutes view ajoutés dans une stack view étaient leakés.