### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ data/
 Pods/
 
 docs/1.2
+
+# Swift Package Manager
+.build/
+.swiftpm/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.5
+import PackageDescription
+
+let package = Package(
+    name: "StackViewLayout",
+    platforms: [
+        .iOS(.v12),
+        .tvOS(.v12)
+    ],
+    products: [
+        .library(name: "StackViewLayout", targets: ["StackViewLayout"])
+    ],
+    targets: [
+        .target(
+            name: "StackViewLayout",
+            path: "Sources",
+            exclude: ["SupportingFiles"]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Fast StackView, Concise syntax, intuitive, readable & chainable. Stacks easily m
 
 
 ### Requirements
-* iOS 9.0+ / tvOS 9.0+
-* Xcode 8.0+ / Xcode 9.0
-* Swift 3.0+ / Swift 4.0
+* iOS 12.0+ / tvOS 12.0+
+* Xcode 15+
+* Swift 5.0+
 
 ### Content
 
@@ -1013,7 +1013,14 @@ Then, run `pod install`.
 NOT IMPLEMENTED YET. COMING SOON.
 
 ### Swift Package Manager
-NOT IMPLEMENTED YET. COMING SOON.
+
+Add it via Xcode (**File › Add Package Dependencies…**) using the repository URL, or in your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/mirego/StackViewLayout.git", branch: "dev")
+```
+
+Once a release is tagged, pin a version with `from:` instead of the branch.
 
 <br>
 


### PR DESCRIPTION
## 📖 Description
Adds a `Package.swift` so this fork can be consumed via **Swift Package Manager** instead of only CocoaPods/Carthage. Mirrors mirego/taylor-ios#55.

## 👷 Work done
- Add `Package.swift`: `StackViewLayout` library, **iOS 12+ / tvOS 12+**, target `path: "Sources"` excluding `SupportingFiles/` (Info plists + umbrella headers).
- `README.md`: update **Requirements** (iOS 12+/tvOS 12+, Xcode 15+, Swift 5+) and fill in the **Swift Package Manager** install section.
- `.gitignore`: ignore `.build/` + `.swiftpm/` (and add the previously-missing trailing newline).

Purely additive — source layout unchanged; CocoaPods/Carthage/Xcode setups keep working. The SPM product/module is `StackViewLayout`, so consumers' `import StackViewLayout` is unaffected.

## ✅ Verification
- `swift package dump-package` — manifest valid.
- Built the package for the iOS Simulator (x86_64 + arm64) → **BUILD SUCCEEDED**.

## 🗒 Note
Only the **library** target is exposed (no test target): `Tests/` are Quick/Nimble BDD specs that would pull extra SPM deps for no consumer benefit — they still run via the existing `.xcodeproj`.

## ⏭️ Follow-up
Cut a tag on `dev` after merge so consumers can pin a version (otherwise SPM has to track the branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)